### PR TITLE
Make loggable objects winston-friendly

### DIFF
--- a/src/Environment/Log/Found.ts
+++ b/src/Environment/Log/Found.ts
@@ -3,16 +3,16 @@ import { Variable } from '../../Variable';
 import { Log } from './Log';
 
 class Found extends Log {
-    public constructor(public readonly variable: Variable) {
-        super();
-    }
+    public readonly message = 'Found environment variable';
+    public readonly found = true;
+    public readonly key: string;
+    public readonly value: string;
 
-    public toJSON(): object {
-        return {
-            found: true,
-            message: 'Found environment variable',
-            ...this.variable.toJSON(),
-        };
+    public constructor(variable: Variable) {
+        super();
+
+        this.key = variable.key;
+        this.value = variable.sensitive ? '*REDACTED*' : variable.value;
     }
 }
 

--- a/src/Environment/Log/Log.ts
+++ b/src/Environment/Log/Log.ts
@@ -1,5 +1,7 @@
 abstract class Log {
-    public abstract toJSON(): object;
+    public abstract readonly message: string;
+    public abstract readonly key: string;
+    public abstract readonly found: boolean;
 }
 
 export { Log };

--- a/src/Environment/Log/Missing.ts
+++ b/src/Environment/Log/Missing.ts
@@ -1,16 +1,11 @@
 import { Log } from './Log';
 
 class Missing extends Log {
+    public readonly message = 'Tried to load an environment variable but not set';
+    public readonly found = false;
+
     public constructor(public readonly key: string) {
         super();
-    }
-
-    public toJSON(): object {
-        return {
-            found: false,
-            message: 'Tried to load an environment variable but not set',
-            key: this.key,
-        };
     }
 }
 

--- a/src/EnvironmentError/ChoiceError.ts
+++ b/src/EnvironmentError/ChoiceError.ts
@@ -3,16 +3,10 @@ import { ReadonlyNonEmptyArray } from 'fp-ts/ReadonlyNonEmptyArray';
 import { EnvironmentError } from './EnvironmentError';
 
 class ChoiceError extends EnvironmentError {
+    public readonly message = 'No decoders succeeded';
+
     public constructor(public readonly errors: ReadonlyNonEmptyArray<EnvironmentError>) {
         super();
-        this.errors = errors;
-    }
-
-    public toJSON(): object {
-        return {
-            message: 'No decoders succeeded',
-            errors: this.errors,
-        };
     }
 }
 

--- a/src/EnvironmentError/DecodeFailed.ts
+++ b/src/EnvironmentError/DecodeFailed.ts
@@ -3,16 +3,16 @@ import { Variable } from '../Variable';
 import { EnvironmentError } from './EnvironmentError';
 
 class DecodeFailed extends EnvironmentError {
-    public constructor(public readonly variable: Variable, public readonly message: string) {
-        super();
-    }
+    public readonly message: string;
+    public readonly key: string;
+    public readonly value: string;
 
-    public toJSON(): object {
-        return {
-            key: this.variable.key,
-            value: this.variable.sensitive ? '*REDACTED*' : this.variable,
-            message: `$${this.variable.key} ${this.message}`,
-        };
+    public constructor(variable: Variable, reason: string) {
+        super();
+
+        this.message = `$${variable.key} ${reason}`;
+        this.key = variable.key;
+        this.value = variable.sensitive ? '*REDACTED*' : variable.value;
     }
 }
 

--- a/src/EnvironmentError/EnvironmentError.ts
+++ b/src/EnvironmentError/EnvironmentError.ts
@@ -1,3 +1,5 @@
-abstract class EnvironmentError {}
+abstract class EnvironmentError {
+    public abstract message: string;
+}
 
 export { EnvironmentError };

--- a/src/EnvironmentError/MissingEnvironmentVariable.ts
+++ b/src/EnvironmentError/MissingEnvironmentVariable.ts
@@ -1,15 +1,10 @@
 import { EnvironmentError } from './EnvironmentError';
 
 class MissingEnvironmentVariable extends EnvironmentError {
+    public readonly message = 'Environment variable not found';
+
     public constructor(public readonly key: string) {
         super();
-    }
-
-    public toJSON(): object {
-        return {
-            key: this.key,
-            message: 'Environment variable not found',
-        };
     }
 }
 

--- a/src/Variable.ts
+++ b/src/Variable.ts
@@ -3,13 +3,6 @@
  */
 class Variable {
     public constructor(public key: string, public value: string, public sensitive: boolean = false) {}
-
-    public toJSON(): object {
-        return {
-            key: this.key,
-            value: this.sensitive ? '*REDACTED*' : this.value,
-        };
-    }
 }
 
 export { Variable };


### PR DESCRIPTION
Our favorite logging library `winston` seems to encode an object into JSON not via `toJSON()` method but via its enumerable properties.